### PR TITLE
Update soundyrust to bevy 0.16

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "soundyrust"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 
 [lints.clippy]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,9 +7,9 @@ edition = "2024"
 eq_op = "allow"
 
 [dependencies]
-bevy = "0.15.0"
+bevy = "0.16.0-rc.5"
 augmented-midi = "1.8.0"
-itertools = "0.13.0"
+itertools = "0.14.0"
 rustysynth = "1.3.2"
 num_enum = "0.7.3"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "soundyrust"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2024"
 
 [lints.clippy]
 eq_op = "allow"
 
 [dependencies]
-bevy = "0.16.0-rc.5"
+bevy = "0.16.0"
 augmented-midi = "1.8.0"
 itertools = "0.14.0"
 rustysynth = "1.3.2"

--- a/examples/live_playing.rs
+++ b/examples/live_playing.rs
@@ -1,11 +1,11 @@
-use bevy::audio::AudioPlugin;
+use bevy::audio::{AudioPlugin, Volume};
 use bevy::prelude::*;
 use soundyrust::*;
 
 fn main() {
 	let mut app = App::new();
 	app.add_plugins(DefaultPlugins.set(AudioPlugin {
-		global_volume: GlobalVolume::new(0.2),
+		global_volume: GlobalVolume::new(Volume::Linear(0.2)),
 		..default()
 	}))
 	.add_plugins(SoundyPlugin)

--- a/examples/midi_octave.rs
+++ b/examples/midi_octave.rs
@@ -1,11 +1,11 @@
-use bevy::audio::AudioPlugin;
+use bevy::audio::{AudioPlugin, Volume};
 use bevy::prelude::*;
 use soundyrust::*;
 
 fn main() {
 	let mut app = App::new();
 	app.add_plugins(DefaultPlugins.set(AudioPlugin {
-		global_volume: GlobalVolume::new(0.2),
+		global_volume: GlobalVolume::new(Volume::Linear(0.2)),
 		..default()
 	}))
 	.add_plugins(SoundyPlugin)

--- a/examples/midi_with_multiple_channels.rs
+++ b/examples/midi_with_multiple_channels.rs
@@ -1,11 +1,11 @@
-use bevy::audio::AudioPlugin;
+use bevy::audio::{AudioPlugin, Volume};
 use bevy::prelude::*;
 use soundyrust::*;
 
 fn main() {
 	let mut app = App::new();
 	app.add_plugins(DefaultPlugins.set(AudioPlugin {
-		global_volume: GlobalVolume::new(0.2),
+		global_volume: GlobalVolume::new(Volume::Linear(0.2)),
 		..default()
 	}))
 	.add_plugins(SoundyPlugin)

--- a/examples/multiple_tracks.rs
+++ b/examples/multiple_tracks.rs
@@ -1,11 +1,11 @@
-use bevy::audio::AudioPlugin;
+use bevy::audio::{AudioPlugin, Volume};
 use bevy::prelude::*;
 use soundyrust::*;
 
 fn main() {
 	let mut app = App::new();
 	app.add_plugins(DefaultPlugins.set(AudioPlugin {
-		global_volume: GlobalVolume::new(0.2),
+		global_volume: GlobalVolume::new(Volume::Linear(0.2)),
 		..default()
 	}))
 	.add_plugins(SoundyPlugin)

--- a/examples/queued_tracks.rs
+++ b/examples/queued_tracks.rs
@@ -1,11 +1,11 @@
-use bevy::audio::AudioPlugin;
+use bevy::audio::{AudioPlugin, Volume};
 use bevy::prelude::*;
 use soundyrust::*;
 
 fn main() {
 	let mut app = App::new();
 	app.add_plugins(DefaultPlugins.set(AudioPlugin {
-		global_volume: GlobalVolume::new(0.2),
+		global_volume: GlobalVolume::new(Volume::Linear(0.2)),
 		..default()
 	}))
 	.add_plugins(SoundyPlugin)

--- a/examples/with_channel_patch.rs
+++ b/examples/with_channel_patch.rs
@@ -1,11 +1,11 @@
-use bevy::audio::AudioPlugin;
+use bevy::audio::{AudioPlugin, Volume};
 use bevy::prelude::*;
 use soundyrust::*;
 
 fn main() {
 	let mut app = App::new();
 	app.add_plugins(DefaultPlugins.set(AudioPlugin {
-		global_volume: GlobalVolume::new(0.2),
+		global_volume: GlobalVolume::new(Volume::Linear(0.2)),
 		..default()
 	}))
 	.add_plugins(SoundyPlugin)

--- a/src/source.rs
+++ b/src/source.rs
@@ -1,11 +1,10 @@
 use std::collections::VecDeque;
 use std::io::Cursor;
 use std::sync::{Arc, Mutex};
-use std::time::Instant;
+use std::time::{Instant, Duration};
 
-use bevy::utils::HashSet;
-use bevy::utils::hashbrown::HashMap;
-use bevy::{audio::Source, prelude::*, utils::Duration};
+use bevy::platform::collections::{HashMap, HashSet};
+use bevy::{audio::Source, prelude::*};
 use num_enum::TryFromPrimitive;
 use rustysynth::{SampleHeader, SoundFont};
 


### PR DESCRIPTION
Updates soundyrust to bevy 0.16.0-rc.5, which will become 0.16.0 upon stable release.

Changes:
- updated bevy "0.15.0" -> "0.16.0-rc.5"
- `HashMap` and `HashSet` are now found in `bevy::platform::collections`
- Volume is now a enum `Volume` instead of a f64, so use `Volume::Linear()` from `bevy::audio`
- updated itertools "0.12.0" -> "0.13.0"